### PR TITLE
Add iCloudContainerEnvironment support when building iOS app requiring this option 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,6 +74,14 @@ platform :ios do
       build_configuration: configuration.buildConfiguration
     )
     unlock_keychain(path: keychain_path, password: keychain_password)
+
+    export_options = {
+      signingStyle: "manual",
+      provisioningProfiles: provisioningProfiles
+    }
+
+    export_options[:iCloudContainerEnvironment] = configuration.iCloudContainerEnvironment unless configuration.iCloudContainerEnvironment.nil? 
+
     build_ios_app(
       workspace: project.workspacePath,
       scheme: project.scheme,
@@ -88,9 +96,6 @@ platform :ios do
       export_team_id: team_id,
       export_method: configuration.exportMethod,
       export_xcargs: "-allowProvisioningUpdates",
-      export_options: {
-        signingStyle: "manual",
-        provisioningProfiles: provisioningProfiles
-      })
+      export_options: export_options)
   end
 end

--- a/fastlane/actions/enterprise_configuration.rb
+++ b/fastlane/actions/enterprise_configuration.rb
@@ -19,13 +19,14 @@ module Model
 
   class Configuration
     attr_reader :certificate, :exportMethod
-    attr_accessor :buildConfiguration, :bundleIdentifierOverride, :provisioningProfile, :extensionProvisioningProfiles
-    def initialize(certificate:, provisioningProfile:, buildConfiguration:, exportMethod:, bundleIdentifierOverride: nil, extensionProvisioningProfiles: {})
+    attr_accessor :buildConfiguration, :bundleIdentifierOverride, :provisioningProfile, :extensionProvisioningProfiles, :iCloudContainerEnvironment
+    def initialize(certificate:, provisioningProfile:, buildConfiguration:, exportMethod:, bundleIdentifierOverride: nil, iCloudContainerEnvironment: nil, extensionProvisioningProfiles: {})
       @certificate = certificate
       @provisioningProfile = provisioningProfile
       @buildConfiguration = buildConfiguration
       @exportMethod = exportMethod
       @bundleIdentifierOverride = bundleIdentifierOverride
+      @iCloudContainerEnvironment = iCloudContainerEnvironment
       @extensionProvisioningProfiles = extensionProvisioningProfiles
     end
   end


### PR DESCRIPTION
## 📖 Description et motivation

This PR adds the iCloudContainerEnvironment export option support when building an iOS app. This is needed when build the Oh She Glows project for the In-App Purchase (QA AdHoc variant).

## 👷 Work done

- [x] Added attribute `iCloudContainerEnvironment` to `Configuration class`.
- [x] When the `iCloudContainerEnvironment` attribute is set, add the value in the `export_options` json that is given to the `build_ios_app` method.

## 📓 References

https://mirego.atlassian.net/browse/OSG-503

## 🦀 Dispatch

- `#dispatch/mobile`