### PR TITLE
Replace disable_automatic_code_signing with update_code_signing_settings

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,7 @@ platform :ios do
     keychain_password = strip_quotes(ENV["keychain_password"])
     keychain_path = "#{ENV["HOME"]}/Library/Keychains/#{keychain_name}.keychain-db"
 
-    update_code_signing_settings(path: project.projectPath)
+    update_code_signing_settings(path: project.projectPath, use_automatic_signing: false)
     install_provisioning_profile(path: configuration.provisioningProfile.path)
 
     team_id = Actions.lane_context[SharedValues::PROVISIONING_TEAM_ID]


### PR DESCRIPTION
`disable_automatic_code_signing` is deprecated and has been replaced by `update_code_signing_settings`.
The default value of `use_automatic_signing ` is already false, so no need to specify

See: 
- https://docs.fastlane.tools/actions/automatic_code_signing/ (old way)
- https://docs.fastlane.tools/actions/update_code_signing_settings (new way)

Note:
I will test on my project before merging