### PR TITLE
Properly reference is_ci from enterprise_configuration action

### DIFF
--- a/fastlane/actions/enterprise_configuration.rb
+++ b/fastlane/actions/enterprise_configuration.rb
@@ -75,7 +75,7 @@ module Fastlane
       def self.run(params)
         is_jenkins_ci = ENV["EXEC_RUNNING_ON_JENKINS"] != nil && strip_quotes(ENV["EXEC_RUNNING_ON_JENKINS"]) == "YES"
 
-        if is_jenkins_ci || IsCiAction.is_ci
+        if is_jenkins_ci || Fastlane::Actions::IsCiAction.is_ci
           genericProvisioningProfile = Model::ProvisioningProfile.new(
             path: "#{strip_quotes(ENV["PROVISIONING_DIR"])}/#{strip_quotes(ENV["PROVISIONING_FILE"])}"
           )

--- a/fastlane/actions/enterprise_configuration.rb
+++ b/fastlane/actions/enterprise_configuration.rb
@@ -75,7 +75,7 @@ module Fastlane
       def self.run(params)
         is_jenkins_ci = ENV["EXEC_RUNNING_ON_JENKINS"] != nil && strip_quotes(ENV["EXEC_RUNNING_ON_JENKINS"]) == "YES"
 
-        if is_jenkins_ci || Fastlane::Actions::IsCiAction.is_ci
+        if is_jenkins_ci || other_action.is_ci
           genericProvisioningProfile = Model::ProvisioningProfile.new(
             path: "#{strip_quotes(ENV["PROVISIONING_DIR"])}/#{strip_quotes(ENV["PROVISIONING_FILE"])}"
           )

--- a/fastlane/actions/enterprise_configuration.rb
+++ b/fastlane/actions/enterprise_configuration.rb
@@ -75,7 +75,7 @@ module Fastlane
       def self.run(params)
         is_jenkins_ci = ENV["EXEC_RUNNING_ON_JENKINS"] != nil && strip_quotes(ENV["EXEC_RUNNING_ON_JENKINS"]) == "YES"
 
-        if is_jenkins_ci || is_ci
+        if is_jenkins_ci || IsCiAction.is_ci
           genericProvisioningProfile = Model::ProvisioningProfile.new(
             path: "#{strip_quotes(ENV["PROVISIONING_DIR"])}/#{strip_quotes(ENV["PROVISIONING_FILE"])}"
           )


### PR DESCRIPTION
Since `enterprise_configuration` is now supported on non CI environment, a check was added to `is_ci` but it seams that we need to reference it with `other_action.is_ci` when used as part of an action.