### PR TITLE
Add disable_xcpretty and include_symbols options

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,6 +29,8 @@ platform :ios do
     configuration = options[:configuration].nil? ? enterprise_configuration() : options[:configuration]
     bundleIdentifier = configuration.bundleIdentifierOverride != nil ? configuration.bundleIdentifierOverride : project.bundleIdentifier
     include_bitcode = options[:include_bitcode].nil? ? true : options[:include_bitcode]
+    include_symbols = options[:include_symbols].nil? ? true : options[:include_symbols]
+    disable_xcpretty = options[:disable_xcpretty].nil? ? false : options[:disable_xcpretty]
     xcargs = options[:xcargs].nil? ? "" : options[:xcargs]
     is_jenkins_ci = ENV["EXEC_RUNNING_ON_JENKINS"] != nil && strip_quotes(ENV["EXEC_RUNNING_ON_JENKINS"]) == "YES"
 
@@ -123,8 +125,9 @@ platform :ios do
       clean: true,
       configuration: configuration.buildConfiguration,
       silent: true,
-      include_symbols: true,
       include_bitcode: include_bitcode,
+      include_symbols: include_symbols,
+      disable_xcpretty: disable_xcpretty,
       skip_profile_detection: true,
       codesigning_identity: configuration.certificate.name,
       xcargs: xcargs,


### PR DESCRIPTION
Add the possibility to specify `include_symbols` and `disable_xcpretty` for the `build_ios_app_with_toolkit` action.