### PR TITLE
Set buildlog_path for iOS builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -136,6 +136,8 @@ platform :ios do
       export_team_id: team_id,
       export_method: configuration.exportMethod,
       export_xcargs: "-allowProvisioningUpdates",
-      export_options: export_options)
+      export_options: export_options,
+      buildlog_path: "./build/logs/"
+    )
   end
 end


### PR DESCRIPTION
Set the directory where to store the raw `xcodebuild` output to `./build/logs/`. Currently, the default value `~/Library/Logs/gym` is used.

Moving the build output to the project's source directory makes the log available to users that have restricted access to the build machine's file system (such as a Jenkins workspace).

## Result

### Before:

```
For the complete and more detailed error log, check the full log at:
/Users/admin/Library/Logs/gym/build-output.log
```

### After:

```
For the complete and more detailed error log, check the full log at:
/Users/admin/Jenkins/jenkins-root/workspace/CHECKOUT/ios/build/logs/build-output.log
```