### PR TITLE
Improve app retrieval by matching bundle ID exactly

### DIFF
--- a/fastlane/actions/upload_build_to_app_store_connect.rb
+++ b/fastlane/actions/upload_build_to_app_store_connect.rb
@@ -206,7 +206,11 @@ module Fastlane
             UI.user_error!("Could not find app with bundle ID: #{params[:app_identifier]}")
           end
           
-          apps.first
+          exact_match = apps.find do |app|
+            app.dig('attributes', 'bundleId') == params[:app_identifier]
+          end
+
+          exact_match || apps.first
         elsif params[:apple_id]
           # Get by Apple ID
           url = URI("https://api.appstoreconnect.apple.com/v1/apps/#{params[:apple_id]}")

--- a/fastlane/actions/upload_build_to_app_store_connect.rb
+++ b/fastlane/actions/upload_build_to_app_store_connect.rb
@@ -198,19 +198,24 @@ module Fastlane
           # Search by bundle identifier
           url = URI("https://api.appstoreconnect.apple.com/v1/apps?filter[bundleId]=#{params[:app_identifier]}")
           response = self.make_api_request(url, api_token, :get)
-          
+
           UI.message("Received following response from Apple for app identifier: #{response}")
 
           apps = response.dig('data')
           if apps.nil? || apps.empty?
             UI.user_error!("Could not find app with bundle ID: #{params[:app_identifier]}")
           end
-          
+
           exact_match = apps.find do |app|
             app.dig('attributes', 'bundleId') == params[:app_identifier]
           end
 
-          exact_match || apps.first
+          if exact_match.nil?
+            found_bundles = apps.map { |app| app.dig('attributes', 'bundleId') }.compact
+            UI.user_error!("Could not find exact match for bundle ID: #{params[:app_identifier]}. Found: #{found_bundles.join(', ')}")
+          end
+
+          exact_match
         elsif params[:apple_id]
           # Get by Apple ID
           url = URI("https://api.appstoreconnect.apple.com/v1/apps/#{params[:apple_id]}")


### PR DESCRIPTION
This pull request improves the app selection logic in the `upload_build_to_app_store_connect.rb` Fastlane action. The main change ensures that when searching for an app by bundle ID, the code now prefers an exact match rather than simply returning the first result.

App selection logic improvement:

* In `find_app`, when searching by bundle ID, the code now selects the app whose `bundleId` exactly matches `params[:app_identifier]`