### PR TITLE
Support building without a workspace using only a project file"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ sampleProject = Model::Project.new(
 )
 ```
 
+If your project does not use a workspace (e.g. no CocoaPods or SPM workspace), you can omit `workspacePath` and provide only `projectPath`:
+
+```ruby
+sampleProject = Model::Project.new(
+  projectPath: "Sample.xcodeproj",
+  infoPlistPath: "Sample/Info.plist",
+  scheme: "Sample",
+  target: "Sample",
+  bundleIdentifier: "com.mirego.Sample"
+)
+```
+
+When `workspacePath` is not provided, the build will use the `.xcodeproj` file directly via `build_ios_app`'s `project:` parameter instead of `workspace:`.
+
 Once it's done, create a lane that import the toolkit and that calls the provided `build_ios_app_with_toolkit` lane with your project. You can either explicitly specify the enterprise configuration by calling `build_ios_app_with_toolkit(project: sampleProject, configuration: enterprise_configuration())` or simply omit the configuration parameter as it is the default value when none is supplied.
 
 ```ruby

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,8 +121,11 @@ platform :ios do
 
     export_options[:iCloudContainerEnvironment] = configuration.iCloudContainerEnvironment unless configuration.iCloudContainerEnvironment.nil?
 
+    use_workspace = !project.workspacePath.nil? && !project.workspacePath.empty?
+    
     build_ios_app(
-      workspace: project.workspacePath,
+      workspace: use_workspace ? project.workspacePath : nil,
+      project: use_workspace ? nil : project.projectPath,
       scheme: project.scheme,
       clean: clean_before_build,
       configuration: configuration.buildConfiguration,

--- a/fastlane/actions/enterprise_configuration.rb
+++ b/fastlane/actions/enterprise_configuration.rb
@@ -6,7 +6,7 @@ module Model
   class Project
     attr_reader :workspacePath, :projectPath, :infoPlistPath, :scheme, :target
     attr_accessor :bundleIdentifier, :extensions
-    def initialize(workspacePath:, projectPath:, infoPlistPath:, scheme:, target:, bundleIdentifier:, extensions: Array.new)
+    def initialize(workspacePath:, projectPath: nil, infoPlistPath:, scheme:, target:, bundleIdentifier:, extensions: Array.new)
       @workspacePath = workspacePath
       @projectPath = projectPath
       @infoPlistPath = infoPlistPath


### PR DESCRIPTION
## Description

Previously, `Model::Project` required both `workspacePath` and `projectPath`, and `build_ios_app` was always called with `workspace:`. This meant projects that only have a `.xcodeproj` (no `.xcworkspace`) couldn't be used with the toolkit without providing a workspace path.

With this change, `workspacePath` becomes optional. If it is present and non-empty, the build uses `workspace:` as before. If it is absent or empty, the build falls back to `project:` using `projectPath`. This is fully backwards-compatible — existing configurations that provide a `workspacePath` are unaffected.

### Changes

- Made `workspacePath` optional in `Model::Project` — projects that don't use a workspace (e.g. no CocoaPods or SPM) can now be built without one
- `build_ios_app_with_toolkit` now passes either `workspace:` or `project:` to `build_ios_app` depending on whether `workspacePath` is set
- Updated the README with a project-only usage example